### PR TITLE
remove object allocation inside draw()

### DIFF
--- a/app/src/main/java/com/sqisland/android/advanced_textview/EmojiActivity.java
+++ b/app/src/main/java/com/sqisland/android/advanced_textview/EmojiActivity.java
@@ -109,6 +109,7 @@ public class EmojiActivity extends Activity {
     private final float textSize;
     private final float strokeWidth;
     private final String number;
+    private Paint paint;
 
     public SpeedSignDrawable(TextView textView, String number) {
       this.ascent = textView.getPaint().ascent();
@@ -120,13 +121,13 @@ public class EmojiActivity extends Activity {
 
       int size = (int) -ascent;
       this.setBounds(0, 0, size, size);
+
+      this.paint = new Paint(Paint.ANTI_ALIAS_FLAG);
     }
 
     @Override
     public void draw(Canvas canvas) {
       int size = (int) -ascent;
-
-      Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
 
       // Draw the circle
       paint.setStyle(Paint.Style.FILL);


### PR DESCRIPTION
Hi @chiuki  great talk!
small PR to avoid allocating object during drawing (since this is an educational sample, it's good to show the best practices :)
